### PR TITLE
[Feature] 게시물 상세 페이지에 인라인 편집 모드 추가- feature/post

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,6 @@ const App = () => (
           <Route path="/pet/:id" element={<AuthGuard><PetDetail /></AuthGuard>} />
           <Route path="/community" element={<AuthGuard><Community /></AuthGuard>} />
           <Route path="/community/new" element={<AuthGuard><PostCreate /></AuthGuard>} />
-          <Route path="/community/edit/:id" element={<AuthGuard><PostEdit /></AuthGuard>} />
           <Route path="/post/:id" element={<AuthGuard><PostDetail /></AuthGuard>} />
           <Route path="/profile" element={<AuthGuard><MyProfile /></AuthGuard>} />
           <Route path="/register" element={<AuthGuard><RegisterPet /></AuthGuard>} />

--- a/src/pages/PostDetail.tsx
+++ b/src/pages/PostDetail.tsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
-import { Heart, MessageSquare, Calendar, ArrowLeft, Eye, User, Edit, Reply, Trash2, MessageCircle } from "lucide-react";
+import { Heart, MessageSquare, Calendar, ArrowLeft, Eye, User, Edit, Reply, Trash2, MessageCircle, FileText, Image, Upload } from "lucide-react";
 import { useState, useEffect } from "react";
 import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
@@ -7,11 +7,16 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Separator } from "@/components/ui/separator";
-import { getPost, deletePost, PostResponse } from "@/api/post";
+import { getPost, deletePost, updatePost, PostResponse } from "@/api/post";
 import { ProtectedImage } from "@/components/ProtectedImage";
 import { getUserProfile, UserProfile } from "@/api/member";
+import { uploadImageToGCP } from "@/api/upload";
+import { useToast } from "@/hooks/use-toast";
+import { ToastAction } from "@/components/ui/toast";
 
 const commentsData = [
   {
@@ -69,11 +74,20 @@ const commentsData = [
 const PostDetail = () => {
   const { id } = useParams();
   const navigate = useNavigate();
+  const { toast } = useToast();
   const [post, setPost] = useState<PostResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [currentUser, setCurrentUser] = useState<UserProfile | null>(null);
-  
+
+  // 편집 모드 상태
+  const [isEditing, setIsEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState("");
+  const [editContent, setEditContent] = useState("");
+  const [editImageFile, setEditImageFile] = useState<File | null>(null);
+  const [editImagePreview, setEditImagePreview] = useState<string | null>(null);
+  const [isUpdating, setIsUpdating] = useState(false);
+
   // 댓글 관련 상태
   const [newComment, setNewComment] = useState("");
   const [replyTo, setReplyTo] = useState<number | null>(null);
@@ -91,45 +105,211 @@ const PostDetail = () => {
     return currentUser && post && currentUser.nickname === post.authorNickname;
   };
 
-  // 게시물 수정 페이지로 이동
-  const handleEditPost = () => {
-    if (isAuthor()) {
-      navigate(`/community/edit/${id}`);
+  // Community로 돌아가는 공통 함수
+  const navigateToCommunity = () => {
+    // Community로 돌아간다는 플래그 설정
+    sessionStorage.setItem('fromPostDetail', 'true');
+
+    const savedState = sessionStorage.getItem('communityState');
+    if (savedState) {
+      const { page, searchTerm, sortBy } = JSON.parse(savedState);
+      const params = new URLSearchParams();
+      params.set('page', page.toString());
+      if (searchTerm) params.set('search', searchTerm);
+      if (sortBy && sortBy !== 'latest') params.set('sort', sortBy);
+      navigate(`/community?${params.toString()}`);
+    } else {
+      navigate('/community');
     }
   };
 
-  // 게시물 삭제
-  const handleDeletePost = async () => {
+  // 편집 모드 활성화
+  const handleEditPost = () => {
+    if (isAuthor() && post) {
+      setEditTitle(post.title);
+      setEditContent(post.content);
+      setEditImageFile(null);
+      setEditImagePreview(null);
+      setIsEditing(true);
+    }
+  };
+
+  // 편집 취소
+  const handleCancelEdit = () => {
+    setIsEditing(false);
+    setEditTitle("");
+    setEditContent("");
+    setEditImageFile(null);
+    setEditImagePreview(null);
+
+    // 게시물 상단으로 스크롤
+    setTimeout(() => {
+      const postContent = document.querySelector('[data-post-content]');
+      if (postContent) {
+        postContent.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    }, 100);
+  };
+
+  // 이미지 변경 핸들러
+  const handleEditImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] || null;
+    setEditImageFile(file);
+    if (file) {
+      const url = URL.createObjectURL(file);
+      setEditImagePreview(url);
+    } else {
+      setEditImagePreview(null);
+    }
+  };
+
+  // 게시물 수정 제출
+  const handleSubmitEdit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!editTitle.trim() || !editContent.trim()) {
+      toast({
+        variant: "destructive",
+        title: "입력 오류",
+        description: "제목과 내용을 모두 입력해주세요.",
+      });
+      return;
+    }
+
+    if (!id) {
+      toast({
+        variant: "destructive",
+        title: "오류",
+        description: "잘못된 게시물 ID입니다.",
+      });
+      return;
+    }
+
+    // 수정 사항이 있는지 확인
+    const hasChanges =
+      editTitle.trim() !== post?.title ||
+      editContent.trim() !== post?.content ||
+      editImageFile !== null;
+
+    if (!hasChanges) {
+      toast({
+        title: "알림",
+        description: "수정 사항이 없습니다.",
+      });
+      return;
+    }
+
+    setIsUpdating(true);
+
+    try {
+      let thumbImageUrl: string | undefined = post?.thumbImageUrl || undefined;
+
+      // 새 이미지가 있으면 업로드
+      if (editImageFile) {
+        const objectName = await uploadImageToGCP(editImageFile);
+        thumbImageUrl = objectName;
+      }
+
+      // 게시물 수정
+      const postData = {
+        title: editTitle.trim(),
+        content: editContent.trim(),
+        thumbImageUrl,
+      };
+
+      const updatedPost = await updatePost(parseInt(id), postData);
+      setPost(updatedPost);
+      setIsEditing(false);
+      toast({
+        title: "수정 완료",
+        description: "게시물이 성공적으로 수정되었습니다.",
+      });
+
+      // 게시물 상단으로 스크롤
+      setTimeout(() => {
+        const postContent = document.querySelector('[data-post-content]');
+        if (postContent) {
+          postContent.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      }, 100);
+    } catch (error) {
+      console.error("게시물 수정 실패:", error);
+      toast({
+        variant: "destructive",
+        title: "수정 실패",
+        description: "게시물 수정에 실패했습니다. 다시 시도해주세요.",
+      });
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  // 게시물 삭제 확인
+  const handleDeletePost = () => {
     if (!isAuthor() || !id) return;
 
-    const confirmDelete = window.confirm("정말로 이 게시물을 삭제하시겠습니까?");
-    if (!confirmDelete) return;
+    toast({
+      title: "게시물 삭제",
+      description: "정말로 이 게시물을 삭제하시겠습니까?",
+      action: (
+        <ToastAction
+          altText="삭제"
+          onClick={() => confirmDeletePost()}
+          className="gap-2 text-red-600 border-red-400 hover:bg-red-600 hover:text-white hover:border-red-600"
+        >
+          삭제
+        </ToastAction>
+      ),
+    });
+  };
+
+  // 실제 삭제 실행
+  const confirmDeletePost = async () => {
+    if (!id) return;
 
     try {
       await deletePost(parseInt(id));
-      alert("게시물이 성공적으로 삭제되었습니다.");
-      navigate("/community");
+      toast({
+        title: "삭제 완료",
+        description: "게시물이 성공적으로 삭제되었습니다.",
+      });
+      navigateToCommunity();
     } catch (error) {
       console.error("게시물 삭제 실패:", error);
-      alert("게시물 삭제에 실패했습니다. 다시 시도해주세요.");
+      toast({
+        variant: "destructive",
+        title: "삭제 실패",
+        description: "게시물 삭제에 실패했습니다. 다시 시도해주세요.",
+      });
     }
   };
 
   // 게시자와 대화하기
   const handleStartChat = () => {
     if (!post || !currentUser) {
-      alert("로그인이 필요합니다.");
+      toast({
+        variant: "destructive",
+        title: "로그인 필요",
+        description: "로그인이 필요합니다.",
+      });
       return;
     }
 
     if (isAuthor()) {
-      alert("본인과는 대화할 수 없습니다.");
+      toast({
+        variant: "destructive",
+        title: "알림",
+        description: "본인과는 대화할 수 없습니다.",
+      });
       return;
     }
 
     // TODO: 채팅방 생성 API 호출
-    // 현재는 임시로 alert만 표시
-    alert(`${post.authorNickname}님과의 채팅방을 생성합니다.`);
+    // 현재는 임시로 toast만 표시
+    toast({
+      title: "채팅방 생성",
+      description: `${post.authorNickname}님과의 채팅방을 생성합니다.`,
+    });
     // navigate('/chat/room-id'); // 실제 채팅방 페이지로 이동
   };
 
@@ -212,9 +392,9 @@ const PostDetail = () => {
         likes: 0,
         parentId: parentId
       };
-      
-      setComments(comments.map(comment => 
-        comment.id === parentId 
+
+      setComments(comments.map(comment =>
+        comment.id === parentId
           ? { ...comment, replies: [...comment.replies, newReply] }
           : comment
       ));
@@ -247,22 +427,7 @@ const PostDetail = () => {
               {error || "게시글을 찾을 수 없습니다"}
             </h1>
             <Button
-              onClick={() => {
-                // Community로 돌아간다는 플래그 설정
-                sessionStorage.setItem('fromPostDetail', 'true');
-
-                const savedState = sessionStorage.getItem('communityState');
-                if (savedState) {
-                  const { page, searchTerm, sortBy } = JSON.parse(savedState);
-                  const params = new URLSearchParams();
-                  params.set('page', page.toString());
-                  if (searchTerm) params.set('search', searchTerm);
-                  if (sortBy && sortBy !== 'latest') params.set('sort', sortBy);
-                  navigate(`/community?${params.toString()}`);
-                } else {
-                  navigate('/community');
-                }
-              }}
+              onClick={navigateToCommunity}
             >
               목록으로 돌아가기
             </Button>
@@ -276,28 +441,13 @@ const PostDetail = () => {
   return (
     <div className="min-h-screen bg-background">
       <Navbar />
-      
+
       <main className="mx-auto px-8 sm:px-16 md:px-24 lg:px-48 py-8">
         {/* Back Button - PetDetail 스타일 */}
         <Button
           variant="ghost"
-          onClick={() => {
-            // Community로 돌아간다는 플래그 설정
-            sessionStorage.setItem('fromPostDetail', 'true');
-
-            const savedState = sessionStorage.getItem('communityState');
-            if (savedState) {
-              const { page, searchTerm, sortBy } = JSON.parse(savedState);
-              const params = new URLSearchParams();
-              params.set('page', page.toString());
-              if (searchTerm) params.set('search', searchTerm);
-              if (sortBy && sortBy !== 'latest') params.set('sort', sortBy);
-              navigate(`/community?${params.toString()}`);
-            } else {
-              navigate('/community');
-            }
-          }}
-          className="mb-8 text-muted-foreground hover:text-foreground"
+          onClick={navigateToCommunity}
+          className="mb-8 text-muted-foreground hover:bg-primary/10 hover:text-primary"
         >
           <ArrowLeft className="h-4 w-4 mr-2" />
           목록으로 돌아가기
@@ -307,7 +457,7 @@ const PostDetail = () => {
         <div className="border-t-2 border-[var(--color-neutral-900)] mb-0"></div>
 
         {/* Post Content */}
-        <div className="px-20 py-16">
+        <div className="px-20 py-16" data-post-content>
           <div className="flex items-center justify-between mb-12">
             <div className="flex items-center gap-2 text-sm text-[var(--color-neutral-700)]">
               <User className="h-4 w-4" />
@@ -328,83 +478,179 @@ const PostDetail = () => {
             )}
           </div>
 
-          <h1 className="text-5xl font-bold text-[var(--color-neutral-900)] mb-12">{post.title}</h1>
-
-          {/* 게시글 메타 정보 */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm text-[var(--color-neutral-700)] mb-16">
-            <div className="flex items-center gap-2">
-              <Calendar className="h-4 w-4" />
-              <span>{new Date(post.createdAt).toLocaleString()}</span>
-            </div>
-            <div className="flex items-center justify-end gap-2">
-              <Eye className="h-4 w-4" />
-              <span>조회 {post.viewCount}</span>
-            </div>
-          </div>
-
-          {/* 수정/삭제 버튼 (작성자에게만 보임) */}
-          {isAuthor() && (
-            <div className="flex justify-end gap-2 mb-8">
-              <Button
-                variant="outline"
-                onClick={handleEditPost}
-                className="gap-2 border-primary/60 text-primary hover:bg-primary/90 hover:text-primary-foreground hover:border-primary/90"
-              >
-                <Edit className="h-4 w-4" />
-                수정하기
-              </Button>
-              <Button
-                variant="outline"
-                onClick={handleDeletePost}
-                className="gap-2 text-red-600 border-red-400 hover:bg-red-600 hover:text-white hover:border-red-600"
-              >
-                <Trash2 className="h-4 w-4" />
-                삭제하기
-              </Button>
-            </div>
-          )}
-
-          {/* 이미지 섹션 */}
-          {post.thumbImageUrl && (
-            <div className="mb-12">
-              <div className="overflow-hidden bg-gray-100 flex items-center justify-center">
-                <ProtectedImage
-                  objectName={post.thumbImageUrl}
-                  alt="게시글 이미지"
-                  className="max-w-full max-h-96 object-contain"
+          {isEditing ? (
+            // 편집 모드
+            <form onSubmit={handleSubmitEdit} className="space-y-8">
+              {/* 제목 편집 */}
+              <div>
+                <Label htmlFor="editTitle" className="text-base font-medium mb-3 block">제목 *</Label>
+                <Input
+                  id="editTitle"
+                  value={editTitle}
+                  onChange={(e) => setEditTitle(e.target.value)}
+                  placeholder="제목을 입력하세요"
+                  required
+                  className="text-2xl font-bold border-2"
                 />
               </div>
-            </div>
+
+              {/* 이미지 편집 */}
+              <div>
+                <Label htmlFor="editImage" className="text-base font-medium mb-3 block">이미지 변경 (선택)</Label>
+
+                {/* 기존 이미지 표시 */}
+                {post.thumbImageUrl && !editImagePreview && (
+                  <div className="mb-4">
+                    <p className="text-sm text-muted-foreground mb-2">현재 이미지:</p>
+                    <ProtectedImage
+                      objectName={post.thumbImageUrl}
+                      alt="현재 이미지"
+                      className="max-w-full max-h-96 object-contain rounded-lg border"
+                    />
+                  </div>
+                )}
+
+                <Input
+                  id="editImage"
+                  type="file"
+                  accept="image/*"
+                  onChange={handleEditImageChange}
+                  className="mb-4"
+                />
+
+                {editImagePreview && (
+                  <div className="mb-4">
+                    <p className="text-sm text-muted-foreground mb-2">새 이미지 미리보기:</p>
+                    <img
+                      src={editImagePreview}
+                      alt="preview"
+                      className="max-w-full max-h-96 object-contain rounded-lg border"
+                    />
+                  </div>
+                )}
+              </div>
+
+              {/* 내용 편집 */}
+              <div>
+                <Label htmlFor="editContent" className="text-base font-medium mb-3 block">내용 *</Label>
+                <Textarea
+                  id="editContent"
+                  value={editContent}
+                  onChange={(e) => setEditContent(e.target.value)}
+                  placeholder="내용을 입력하세요"
+                  rows={15}
+                  required
+                  className="text-lg leading-relaxed"
+                />
+              </div>
+
+              {/* 편집 모드 버튼들 */}
+              <div className="flex justify-end gap-4">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleCancelEdit}
+                  disabled={isUpdating}
+                  className="gap-2 text-red-600 border-red-400 hover:bg-red-600 hover:text-white hover:border-red-600"
+                >
+                  취소
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={isUpdating}
+                  className="bg-primary hover:bg-primary/90"
+                >
+                  {isUpdating ? "수정 중..." : "수정 완료"}
+                </Button>
+              </div>
+            </form>
+          ) : (
+            // 읽기 모드
+            <>
+              <h1 className="text-5xl font-bold text-[var(--color-neutral-900)] mb-12">{post.title}</h1>
+
+              {/* 게시글 메타 정보 */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6 text-sm text-[var(--color-neutral-700)] mb-16">
+                <div className="flex items-center gap-2">
+                  <Calendar className="h-4 w-4" />
+                  <span>{new Date(post.createdAt).toLocaleString()}</span>
+                </div>
+                <div className="flex items-center justify-end gap-2">
+                  <Eye className="h-4 w-4" />
+                  <span>조회 {post.viewCount}</span>
+                </div>
+              </div>
+
+              {/* 수정/삭제 버튼 (작성자에게만 보임) */}
+              {isAuthor() && (
+                <div className="flex justify-end gap-2 mb-8">
+                  <Button
+                    variant="outline"
+                    onClick={handleEditPost}
+                    className="gap-2 border-primary/60 text-primary hover:bg-primary/90 hover:text-primary-foreground hover:border-primary/90"
+                  >
+                    <Edit className="h-4 w-4" />
+                    수정하기
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={handleDeletePost}
+                    className="gap-2 text-red-600 border-red-400 hover:bg-red-600 hover:text-white hover:border-red-600"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    삭제하기
+                  </Button>
+                </div>
+              )}
+
+              {/* 이미지 섹션 */}
+              {post.thumbImageUrl && (
+                <div className="mb-12">
+                  <div className="overflow-hidden bg-gray-100 flex items-center justify-center">
+                    <ProtectedImage
+                      objectName={post.thumbImageUrl}
+                      alt="게시글 이미지"
+                      className="max-w-full max-h-96 object-contain"
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* 본문 내용 */}
+              <div className="prose prose-lg max-w-none mb-12">
+                <div className="whitespace-pre-wrap text-[var(--color-neutral-900)] leading-relaxed text-xl">
+                  {post.content}
+                </div>
+              </div>
+            </>
           )}
 
-          {/* 본문 내용 */}
-          <div className="prose prose-lg max-w-none mb-12">
-            <div className="whitespace-pre-wrap text-[var(--color-neutral-900)] leading-relaxed text-xl">
-              {post.content}
-            </div>
-          </div>
+          {!isEditing && (
+            <>
+              <div className="my-12">
+                <div className="border-t border-[var(--color-neutral-200)]"></div>
+              </div>
 
-          <div className="my-12">
-            <div className="border-t border-[var(--color-neutral-200)]"></div>
-          </div>
-
-          {/* 액션 버튼들 */}
-          <div className="flex items-center justify-center gap-6">
-            <Button variant="outline" className="gap-2 py-3 px-6 border-gray-400 text-gray-700 hover:bg-primary/10 hover:text-primary hover:border-primary/40">
-              <Heart className="h-4 w-4" />
-              좋아요
-            </Button>
-            <Button variant="outline" className="gap-2 py-3 px-6 border-gray-400 text-gray-700 hover:bg-primary/10 hover:text-primary hover:border-primary/40">
-              <MessageSquare className="h-4 w-4" />
-              댓글 {comments.reduce((total, comment) => total + 1 + comment.replies.length, 0)}
-            </Button>
-          </div>
+              {/* 액션 버튼들 */}
+              <div className="flex items-center justify-center gap-6">
+                <Button variant="outline" className="gap-2 py-3 px-6 border-gray-400 text-gray-700 hover:bg-primary/10 hover:text-primary hover:border-primary/40">
+                  <Heart className="h-4 w-4" />
+                  좋아요
+                </Button>
+                <Button variant="outline" className="gap-2 py-3 px-6 border-gray-400 text-gray-700 hover:bg-primary/10 hover:text-primary hover:border-primary/40">
+                  <MessageSquare className="h-4 w-4" />
+                  댓글 {comments.reduce((total, comment) => total + 1 + comment.replies.length, 0)}
+                </Button>
+              </div>
+            </>
+          )}
         </div>
 
         {/* Bottom Border */}
-        <div className="border-b-2 border-[var(--color-neutral-900)] mt-0 mb-10"></div>
+        {!isEditing && <div className="border-b-2 border-[var(--color-neutral-900)] mt-0 mb-10"></div>}
 
-        {/* Comments Section */}
+        {/* Comments Section - 편집 모드가 아닐 때만 표시 */}
+        {!isEditing && (
          <div className="px-20 ">
            <Card className="mx-0">
              <CardHeader className="px-20 pt-12">
@@ -413,7 +659,7 @@ const PostDetail = () => {
              <CardContent className="px-20">
             {/* Comment Form */}
             <div className="mb-6">
-              <Textarea 
+              <Textarea
                 placeholder="댓글을 작성해주세요..."
                 className="mb-3"
                 rows={3}
@@ -449,9 +695,9 @@ const PostDetail = () => {
                         <Heart className="h-3 w-3 mr-1" />
                         {comment.likes}
                       </Button>
-                        <Button 
-                          variant="ghost" 
-                          size="sm" 
+                        <Button
+                          variant="ghost"
+                          size="sm"
                           className="h-7 px-2 text-muted-foreground hover:text-primary"
                           onClick={() => setReplyTo(replyTo === comment.id ? null : comment.id)}
                         >
@@ -465,7 +711,7 @@ const PostDetail = () => {
                   {/* Reply Form */}
                   {replyTo === comment.id && (
                     <div className="ml-11 border-l-2 border-[var(--color-neutral-200)] pl-4">
-                      <Textarea 
+                      <Textarea
                         placeholder={`${comment.author}님에게 답글 달기...`}
                         className="mb-3"
                         rows={2}
@@ -523,6 +769,7 @@ const PostDetail = () => {
           </CardContent>
         </Card>
          </div>
+        )}
       </main>
 
       <Footer />


### PR DESCRIPTION
- 게시물 수정 시 별도 페이지 이동 없이 현재 페이지에서 편집 가능
- 조회수 중복 증가 문제 해결 (수정 시 페이지 이동으로 인한 2회 증가 방지)
- 편집/취소/완료 시 게시물 상단으로 자동 스크롤
- 수정 사항 없을 시 알림 표시
- alert 대신 toast UI 사용으로 일관성 있는 사용자 경험 제공
- 삭제 확인도 toast로 변경하여 더 세련된 UI 구현
- 중복 코드 제거: Community 돌아가기 로직 공통 함수화
- PostEdit 페이지는 보존하되 라우팅에서 제외